### PR TITLE
Fixing import errors

### DIFF
--- a/flock_drone/api_docs/doc_gen.py
+++ b/flock_drone/api_docs/doc_gen.py
@@ -12,7 +12,7 @@ import os
 import sys
 import json
 from flock_drone.settings import HYDRUS_SERVER_URL
-from hydrus.hydraspec.doc_writer import HydraDoc, HydraClass, HydraClassProp, HydraClassOp
+from hydra_python_core.doc_writer import HydraDoc, HydraClass, HydraClassProp, HydraClassOp
 
 
 def doc_gen(API, BASE_URL):

--- a/flock_drone/main.py
+++ b/flock_drone/main.py
@@ -10,7 +10,7 @@ from hydrus.app import app_factory
 from hydrus.utils import set_session, set_doc, set_hydrus_server_url
 # from hydrus.app import set_session, set_doc, set_hydrus_server_url
 from hydrus.data import doc_parse
-from hydrus.hydraspec import doc_maker
+from hydra_python_core import doc_maker
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from hydrus.data.db_models import Base

--- a/flock_drone/main.py
+++ b/flock_drone/main.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 
     print("Done")
 
-    apidoc = doc_maker.createDoc(doc, HYDRUS_SERVER_URL, API_NAME)
+    apidoc = doc_maker.create_doc(doc, HYDRUS_SERVER_URL, API_NAME)
 
     session = sessionmaker(bind=engine)()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,9 @@ gevent==1.2.2
 greenlet==0.4.12
 haversine==0.4.5
 httplib2==0.10.3
--e git://github.com/andrejsab/hydra-py.git@ff78005b3ff1902e53b6faacff17498d105cd80a#egg=hydra
--e git://github.com/HTTP-APIs/hydrus.git@9d9f68d37ff961496ac31d0e774086429665409e#egg=hydrus
+-e git://github.com/HTTP-APIs/hydra-openapi-parser.git#egg=hydra-openapi-parser
+-e git://github.com/pchampin/hydra-py.git#egg=hydra
+-e git://github.com/HTTP-APIs/hydrus.git#egg=hydrus
 -e git://github.com/HTTP-APIs/hydra-python-core.git#egg=hydra_python_core
 idna==2.5
 isodate==0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ haversine==0.4.5
 httplib2==0.10.3
 -e git://github.com/andrejsab/hydra-py.git@ff78005b3ff1902e53b6faacff17498d105cd80a#egg=hydra
 -e git://github.com/HTTP-APIs/hydrus.git@9d9f68d37ff961496ac31d0e774086429665409e#egg=hydrus
+-e git://github.com/HTTP-APIs/hydra-python-core.git#egg=hydra_python_core
 idna==2.5
 isodate==0.5.4
 itsdangerous==0.24


### PR DESCRIPTION
Fixes #

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description

On the [PR #353](https://github.com/HTTP-APIs/hydrus/commit/525b694f200ad87855327af24e8d1426078b0989) of hydrus repo, was made a port hydraspec to hydra_python_core and that made this repo outdate.


#### Fixed
That's solve one bug on hydra-flock-demo, when the script bootstrap-dev.sh run it gives this import error:

ModuleNotFoundError: No module named 'hydrus.hydraspec'

Now it's solved.